### PR TITLE
Add POP3 honeypot server

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,3 +41,23 @@ The IMAP profile supports custom responses for standard commands. In addition to
 `LOGIN` and `LOGOUT`, the handler understands the `STARTTLS`, `AUTHENTICATE`, and
 `NOOP` commands, returning the strings configured in the profile.
 
+
+## POP3 honeypot
+
+`mailpot/pop3.py` provides a small POP3 server that works the same way as the SMTP and IMAP honeypots. It reads its replies from `/var/local/mailpot/pop3_profile.json` unless another file is supplied with `--config`.
+
+```bash
+python3 -m mailpot.pop3 --host 0.0.0.0 --port 1110 --config pop3_profile.json
+```
+
+A minimal profile might look like:
+
+```json
+{
+  "banner": "+OK POP3 ready",
+  "STAT": "+OK 0 0",
+  "LIST": "+OK 0 messages\n.",
+  "RETR": "+OK 0 octets\n.",
+  "QUIT": "+OK bye"
+}
+```

--- a/mailpot/pop3.py
+++ b/mailpot/pop3.py
@@ -1,0 +1,122 @@
+#!/usr/bin/env python3
+"""Simple POP3 honeypot server."""
+
+import argparse
+import json
+import logging
+import socketserver
+import sys
+import syslog
+import time
+
+DEFAULT_CONFIG = "/var/local/mailpot/pop3_profile.json"
+
+
+class POP3Handler(socketserver.StreamRequestHandler):
+    """Handle POP3 interactions based on a JSON profile."""
+
+    def handle(self) -> None:
+        peer = self.connection.getpeername()
+        syslog.syslog(syslog.LOG_INFO, f"[pop3-honeypot] Connection from {peer[0]}:{peer[1]}")
+        self.server.logger.info("Connection from %s:%s", peer[0], peer[1])
+
+        def send(line: str) -> None:
+            self.wfile.write((line + "\r\n").encode("utf-8"))
+
+        def expect() -> str:
+            return self.rfile.readline().decode("utf-8", errors="ignore").strip()
+
+        profile = self.server.profile
+        send(profile.get("banner", "+OK POP3 ready"))
+
+        while True:
+            try:
+                line = expect()
+                if not line:
+                    break
+                cmd = line.split()[0].upper()
+
+                if cmd == "USER":
+                    send(profile.get("USER", "+OK"))
+                elif cmd == "PASS":
+                    time.sleep(self.server.fail_delay)
+                    send(profile.get("PASS", "-ERR invalid login"))
+                elif cmd == "STAT":
+                    send(profile.get("STAT", "+OK 0 0"))
+                elif cmd == "LIST":
+                    resp = profile.get("LIST", "+OK 0 messages")
+                    for l in resp.split("\n"):
+                        send(l)
+                    if not resp.endswith("\n.") and resp.split("\n")[-1] != ".":
+                        send(".")
+                elif cmd == "RETR":
+                    resp = profile.get("RETR", "+OK 0 octets")
+                    for l in resp.split("\n"):
+                        send(l)
+                    if not resp.endswith("\n.") and resp.split("\n")[-1] != ".":
+                        send(".")
+                elif cmd == "DELE":
+                    send(profile.get("DELE", "+OK"))
+                elif cmd == "NOOP":
+                    send(profile.get("NOOP", "+OK"))
+                elif cmd == "RSET":
+                    send(profile.get("RSET", "+OK"))
+                elif cmd == "QUIT":
+                    send(profile.get("QUIT", "+OK bye"))
+                    break
+                else:
+                    key = line if line in profile else cmd
+                    send(profile.get(key, "-ERR unrecognized command"))
+            except Exception as exc:  # pragma: no cover - logging
+                msg = f"[pop3-honeypot] Error: {exc}"
+                syslog.syslog(syslog.LOG_ERR, msg)
+                self.server.logger.error(msg)
+                break
+
+
+class POP3Server(socketserver.ThreadingTCPServer):
+    allow_reuse_address = True
+
+    def __init__(self, addr, handler, profile: dict, fail_delay: int, logger: logging.Logger):
+        super().__init__(addr, handler)
+        self.profile = profile
+        self.fail_delay = fail_delay
+        self.logger = logger
+
+
+def load_profile(path: str) -> dict:
+    try:
+        with open(path, "r", encoding="utf-8") as f:
+            return json.load(f)
+    except FileNotFoundError:
+        return {}
+
+
+def main(argv=None) -> int:
+    parser = argparse.ArgumentParser(description="POP3 Honeypot Daemon")
+    parser.add_argument("--host", default="0.0.0.0", help="Listen address")
+    parser.add_argument("--port", type=int, default=110, help="Listen port")
+    parser.add_argument("--config", default=DEFAULT_CONFIG, help="Path to POP3 profile JSON")
+    parser.add_argument("--fail-delay", type=int, default=3, help="Delay in seconds after failed PASS")
+    args = parser.parse_args(argv)
+
+    logger = logging.getLogger("pop3-honeypot")
+    logging.basicConfig(level=logging.INFO)
+
+    profile = load_profile(args.config)
+
+    server = POP3Server((args.host, args.port), POP3Handler, profile, args.fail_delay, logger)
+
+    logger.info("Starting POP3 honeypot on %s:%s", args.host, args.port)
+    syslog.openlog("pop3-honeypot")
+    try:
+        server.serve_forever()
+    except KeyboardInterrupt:
+        logger.info("Interrupted by user")
+    finally:
+        server.server_close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/pop3_profile.json
+++ b/pop3_profile.json
@@ -1,0 +1,12 @@
+{
+  "banner": "+OK POP3 ready",
+  "USER": "+OK",
+  "PASS": "-ERR invalid login",
+  "STAT": "+OK 0 0",
+  "LIST": "+OK 0 messages\n.",
+  "RETR": "+OK 0 octets\n.",
+  "DELE": "+OK",
+  "NOOP": "+OK",
+  "RSET": "+OK",
+  "QUIT": "+OK bye"
+}


### PR DESCRIPTION
## Summary
- add `mailpot/pop3.py` implementing a POP3 honeypot similar to the SMTP/IMAP versions
- provide a default profile `pop3_profile.json`
- document running the POP3 honeypot in the README

## Testing
- `python3 -m py_compile mailpot/*.py pop3_harvester.py imap_harvester.py smtp_harvester.py`

------
https://chatgpt.com/codex/tasks/task_e_685e6608df14832d81cf346c543472df