### PR TITLE
Ensure Python 3.4 compatibility

### DIFF
--- a/imap_harvester.py
+++ b/imap_harvester.py
@@ -7,18 +7,18 @@ IMAP_PORT = 143
 
 responses = {}
 
-print(f"Connecting to {IMAP_HOST}:{IMAP_PORT}...")
+print("Connecting to {}:{}...".format(IMAP_HOST, IMAP_PORT))
 with socket.create_connection((IMAP_HOST, IMAP_PORT), timeout=60) as sock:
     file = sock.makefile("rwb", buffering=0)
 
     def recv_line():
         line = file.readline().decode("utf-8", errors="ignore").strip()
-        print(f"RECV: {line}")
+        print("RECV: {}".format(line))
         return line
 
     def send(tag, cmd):
-        full = f"{tag} {cmd}"
-        print(f"SENT: {full}")
+        full = "{} {}".format(tag, cmd)
+        print("SENT: {}".format(full))
         file.write((full + "\r\n").encode("utf-8"))
         time.sleep(0.5)
         return recv_line()

--- a/pop3_harvester.py
+++ b/pop3_harvester.py
@@ -7,13 +7,13 @@ POP3_PORT = 110
 
 responses = {}
 
-print(f"Connecting to {POP3_HOST}:{POP3_PORT}...")
+print("Connecting to {}:{}...".format(POP3_HOST, POP3_PORT))
 with socket.create_connection((POP3_HOST, POP3_PORT), timeout=60) as sock:
     file = sock.makefile("rwb", buffering=0)
 
     def recv_line():
         line = file.readline().decode("utf-8", errors="ignore").strip()
-        print(f"RECV: {line}")
+        print("RECV: {}".format(line))
         return line
 
     def recv_multiline():
@@ -26,7 +26,7 @@ with socket.create_connection((POP3_HOST, POP3_PORT), timeout=60) as sock:
         return "\n".join(lines)
 
     def send(cmd, multiline=False):
-        print(f"SENT: {cmd}")
+        print("SENT: {}".format(cmd))
         file.write((cmd + "\r\n").encode("utf-8"))
         time.sleep(0.5)
         return recv_multiline() if multiline else recv_line()

--- a/servers/imap.py
+++ b/servers/imap.py
@@ -17,7 +17,7 @@ class IMAPHandler(socketserver.StreamRequestHandler):
 
     def handle(self) -> None:
         peer = self.connection.getpeername()
-        syslog.syslog(syslog.LOG_INFO, f"[imap-honeypot] Connection from {peer[0]}:{peer[1]}")
+        syslog.syslog(syslog.LOG_INFO, "[imap-honeypot] Connection from {}:{}".format(peer[0], peer[1]))
         self.server.logger.info("Connection from %s:%s", peer[0], peer[1])
 
         def send(line: str) -> None:
@@ -28,7 +28,7 @@ class IMAPHandler(socketserver.StreamRequestHandler):
 
         profile = self.server.profile
         banner = profile.get("banner", "OK IMAP4rev1 Service Ready")
-        send(f"* {banner}")
+        send("* {}".format(banner))
 
         while True:
             try:
@@ -44,29 +44,29 @@ class IMAPHandler(socketserver.StreamRequestHandler):
                 if cmd == "LOGIN":
                     time.sleep(self.server.fail_delay)
                     resp = profile.get("LOGIN", "NO LOGIN failed")
-                    send(f"{tag} {resp}")
+                    send("{} {}".format(tag, resp))
                 elif cmd == "STARTTLS":
                     resp = profile.get("STARTTLS", "OK Begin TLS negotiation now")
-                    send(f"{tag} {resp}")
+                    send("{} {}".format(tag, resp))
                 elif cmd == "AUTHENTICATE":
                     time.sleep(self.server.fail_delay)
                     resp = profile.get("AUTHENTICATE", "NO AUTHENTICATE not supported")
-                    send(f"{tag} {resp}")
+                    send("{} {}".format(tag, resp))
                 elif cmd == "NOOP":
                     resp = profile.get("NOOP", "OK NOOP completed")
-                    send(f"{tag} {resp}")
+                    send("{} {}".format(tag, resp))
                 elif cmd == "LOGOUT":
                     resp = profile.get("LOGOUT", "OK LOGOUT completed")
                     bye = profile.get("BYE", "BYE Logging out")
-                    send(f"* {bye}")
-                    send(f"{tag} {resp}")
+                    send("* {}".format(bye))
+                    send("{} {}".format(tag, resp))
                     break
                 else:
                     key = line if line in profile else cmd
                     resp = profile.get(key, "BAD Command not recognized")
-                    send(f"{tag} {resp}")
+                    send("{} {}".format(tag, resp))
             except Exception as exc:  # pragma: no cover - logging
-                msg = f"[imap-honeypot] Error: {exc}"
+                msg = "[imap-honeypot] Error: {}".format(exc)
                 syslog.syslog(syslog.LOG_ERR, msg)
                 self.server.logger.error(msg)
                 break

--- a/servers/pop3.py
+++ b/servers/pop3.py
@@ -17,7 +17,7 @@ class POP3Handler(socketserver.StreamRequestHandler):
 
     def handle(self) -> None:
         peer = self.connection.getpeername()
-        syslog.syslog(syslog.LOG_INFO, f"[pop3-honeypot] Connection from {peer[0]}:{peer[1]}")
+        syslog.syslog(syslog.LOG_INFO, "[pop3-honeypot] Connection from {}:{}".format(peer[0], peer[1]))
         self.server.logger.info("Connection from %s:%s", peer[0], peer[1])
 
         def send(line: str) -> None:
@@ -68,7 +68,7 @@ class POP3Handler(socketserver.StreamRequestHandler):
                     key = line if line in profile else cmd
                     send(profile.get(key, "-ERR unrecognized command"))
             except Exception as exc:  # pragma: no cover - logging
-                msg = f"[pop3-honeypot] Error: {exc}"
+                msg = "[pop3-honeypot] Error: {}".format(exc)
                 syslog.syslog(syslog.LOG_ERR, msg)
                 self.server.logger.error(msg)
                 break

--- a/servers/smtp.py
+++ b/servers/smtp.py
@@ -17,7 +17,7 @@ class SMTPHandler(socketserver.StreamRequestHandler):
 
     def handle(self) -> None:
         peer = self.connection.getpeername()
-        syslog.syslog(syslog.LOG_INFO, f"[smtp-honeypot] Connection from {peer[0]}:{peer[1]}")
+        syslog.syslog(syslog.LOG_INFO, "[smtp-honeypot] Connection from {}:{}".format(peer[0], peer[1]))
         self.server.logger.info("Connection from %s:%s", peer[0], peer[1])
 
         def send(line: str) -> None:
@@ -60,7 +60,7 @@ class SMTPHandler(socketserver.StreamRequestHandler):
                     key = line if line in profile else cmd
                     send(profile.get(key, "502 5.5.2 Command not recognized"))
             except Exception as exc:  # pragma: no cover - logging
-                msg = f"[smtp-honeypot] Error: {exc}"
+                msg = "[smtp-honeypot] Error: {}".format(exc)
                 syslog.syslog(syslog.LOG_ERR, msg)
                 self.server.logger.error(msg)
                 break


### PR DESCRIPTION
## Summary
- remove f-string usage so that the scripts run on Python 3.4
- update all harvesters and server modules

## Testing
- `python3 -m py_compile smtp_harvester.py imap_harvester.py pop3_harvester.py servers/*.py`

------
https://chatgpt.com/codex/tasks/task_e_685eb5163118832d8a35a684c3fde1b7