### PR TITLE
Improve EHLO handling in SMTP server and harvester

### DIFF
--- a/servers/smtp.py
+++ b/servers/smtp.py
@@ -11,6 +11,22 @@ import time
 
 DEFAULT_CONFIG = "/var/local/mailpot/smtp_profile.json"
 
+# Default responses used when no profile entry is found.  The EHLO response
+# mirrors a typical multi-line reply from a real SMTP server.
+DEFAULT_HELO = "250 smtp.mx.profiweb.biz"
+DEFAULT_EHLO = (
+    "250-smtp.mx.profiweb.biz\n"
+    "250-PIPELINING\n"
+    "250-SIZE 1073741824\n"
+    "250-VRFY\n"
+    "250-ETRN\n"
+    "250-STARTTLS\n"
+    "250-AUTH PLAIN LOGIN\n"
+    "250-ENHANCEDSTATUSCODES\n"
+    "250-8BITMIME\n"
+    "250 DSN"
+)
+
 
 class SMTPHandler(socketserver.StreamRequestHandler):
     """Handle SMTP interactions based on a JSON profile."""
@@ -83,7 +99,8 @@ class SMTPHandler(socketserver.StreamRequestHandler):
                             key = alias_cmd
                         else:
                             key = cmd
-                    send(profile.get(key, "250 Ok"))
+                    default_resp = DEFAULT_EHLO if cmd == "EHLO" else DEFAULT_HELO
+                    send(profile.get(key, default_resp))
                 elif cmd == "QUIT":
                     send(profile.get("QUIT", "221 Bye"))
                     break

--- a/smtp_harvester.py
+++ b/smtp_harvester.py
@@ -31,7 +31,9 @@ with socket.create_connection((SMTP_HOST, SMTP_PORT), timeout=60) as sock:
     print("Getting banner...")
     responses["banner"] = recv_response()
 
-    responses["EHLO test.local"] = send("EHLO test.local")
+    # EHLO responses are often multi-line and contain server capabilities.
+    resp_ehlo = send("EHLO test.local")
+    responses["EHLO test.local"] = resp_ehlo
     responses["AUTH PLAIN"] = send("AUTH PLAIN {}".format(base64.b64encode(b"\0user\0pass").decode()))
     responses["AUTH LOGIN"] = send("AUTH LOGIN")
     responses["AUTH LOGIN user"] = send(base64.b64encode(b"user").decode())


### PR DESCRIPTION
## Summary
- support multi-line EHLO defaults for the SMTP honeypot
- keep standard single-line reply for HELO
- record EHLO response when harvesting profiles

## Testing
- `python3 -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6862709a2ab4832db752077a5e2464c7